### PR TITLE
Issue#40

### DIFF
--- a/boot/read.go
+++ b/boot/read.go
@@ -26,5 +26,3 @@ func ParseRuntimeArgs(argv []string) error {
 
 	return nil
 }
-// ----------
-// ---------------

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,8 @@ go 1.23.0
 toolchain go1.23.9
 
 require github.com/google/uuid v1.6.0
+
+require (
+	golang.org/x/sys v0.35.0 // indirect
+	golang.org/x/term v0.34.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.34.0 h1:O/2T7POpk0ZZ7MAzMeWFSg6S5IpWd/RXDlM9hgM3DR4=
+golang.org/x/term v0.34.0/go.mod h1:5jC53AEywhIVebHgPVeg0mj8OD3VO9OzclacVrqpaAw=

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"mycelia/boot"
 	"mycelia/server"
@@ -20,21 +19,32 @@ var startupBanner string = `
 
 var disclaimer string = "Mycelia is a work-in-progress concurrent message broker."
 
+var majorVersion int = 0
+var minorVersion int = 5
+var patchVersion int = 0
+var brokerVersion string = fmt.Sprintf(
+	"%d.%d.%d", majorVersion, minorVersion, patchVersion,
+)
+var verNotice string = fmt.Sprintf(
+	"Running verison: %s", brokerVersion,
+)
+
 func main() {
 	displayStartupText()
 	readArgs()
+
 	startServer() // Must be last, contains infinite for loop.
 }
 
 // Prints ascii banner, disclaimer text, and any misc info.
 func displayStartupText() {
-	line := strings.Repeat("-", 80)
-
-	fmt.Println(line)
+	str.PrintAsciiLine()
 	fmt.Println(startupBanner)
-	fmt.Println(line)
+	str.PrintAsciiLine()
+	fmt.Println(verNotice)
+	str.PrintAsciiLine()
 	fmt.Println(disclaimer)
-	fmt.Println(line)
+	str.PrintAsciiLine()
 }
 
 func readArgs() {

--- a/parsing/one.go
+++ b/parsing/one.go
@@ -6,6 +6,16 @@ import (
 	"mycelia/commands"
 )
 
+// Version 1 of the command API does not support sub-command parsing.
+// The <object>.<action> syntax is the conform to future version feature syntax.
+const (
+	CMD_MESSAGE_SEND    = "MESSAGE.SEND"
+	CMD_ROUTE_ADD       = "ROUTE.ADD"
+	CMD_CHANNEL_ADD     = "CHANNEL.ADD"
+	CMD_SUBSCRIBER_ADD  = "SUBSCRIBER.ADD"
+	CMD_TRANSFORMER_ADD = "TRANSFORMER.ADD"
+)
+
 // -----------------------------------------------------------------------------
 // Version 1 command decoding.
 // Currently handles arrays of string tokens - will convert to byte array and
@@ -19,15 +29,15 @@ func parseDataV1(tokens []string) (string, commands.Command) {
 	var cmd commands.Command
 
 	switch cmdType {
-	case "send_message":
+	case CMD_MESSAGE_SEND:
 		s, cmd = parseSendMsgV1(cmdTokens)
-	case "add_route":
+	case CMD_ROUTE_ADD:
 		s, cmd = parseAddRouteV1(cmdTokens)
-	case "add_subscriber":
-		s, cmd = parseAddSubscriberV1(cmdTokens)
-	case "add_channel":
+	case CMD_CHANNEL_ADD:
 		s, cmd = parseAddChannelV1(cmdTokens)
-	case "add_transformer":
+	case CMD_SUBSCRIBER_ADD:
+		s, cmd = parseAddSubscriberV1(cmdTokens)
+	case CMD_TRANSFORMER_ADD:
 		s, cmd = parseAddTransformerV1(cmdTokens)
 	}
 

--- a/parsing/one.go
+++ b/parsing/one.go
@@ -51,8 +51,8 @@ func parseDataV1(tokens []string) (string, commands.Command) {
 // -----------------------------------------------------------------------------
 
 func parseSendMsgV1(tokens []string) (string, commands.Command) {
-	if !verifyTokenLength(tokens, 3, "send_message") {
-		return "send_message", nil
+	if !verifyTokenLength(tokens, 3, CMD_MESSAGE_SEND) {
+		return CMD_MESSAGE_SEND, nil
 	}
 
 	sm := commands.NewSendMessage(
@@ -60,25 +60,25 @@ func parseSendMsgV1(tokens []string) (string, commands.Command) {
 		tokens[1], // Route
 		tokens[2], // Body
 	)
-	return "send_message", sm
+	return CMD_MESSAGE_SEND, sm
 }
 
 func parseAddRouteV1(tokens []string) (string, commands.Command) {
 	fmt.Println(tokens)
-	if !verifyTokenLength(tokens, 2, "add_route") {
-		return "add_route", nil
+	if !verifyTokenLength(tokens, 2, CMD_ROUTE_ADD) {
+		return CMD_ROUTE_ADD, nil
 	}
 
 	ar := commands.NewAddRoute(
 		tokens[0], // ID
 		tokens[1], // Name
 	)
-	return "add_route", ar
+	return CMD_ROUTE_ADD, ar
 }
 
 func parseAddSubscriberV1(tokens []string) (string, commands.Command) {
-	if !verifyTokenLength(tokens, 4, "add_subscriber") {
-		return "add_subscriber", nil
+	if !verifyTokenLength(tokens, 4, CMD_SUBSCRIBER_ADD) {
+		return CMD_SUBSCRIBER_ADD, nil
 	}
 
 	as := commands.NewAddSubscriber(
@@ -87,12 +87,12 @@ func parseAddSubscriberV1(tokens []string) (string, commands.Command) {
 		tokens[2], // Channel
 		tokens[3], // Address
 	)
-	return "add_subscriber", as
+	return CMD_SUBSCRIBER_ADD, as
 }
 
 func parseAddChannelV1(tokens []string) (string, commands.Command) {
-	if !verifyTokenLength(tokens, 3, "add_channel") {
-		return "add_channel", nil
+	if !verifyTokenLength(tokens, 3, CMD_CHANNEL_ADD) {
+		return CMD_CHANNEL_ADD, nil
 	}
 
 	ac := commands.NewAddChannel(
@@ -100,12 +100,12 @@ func parseAddChannelV1(tokens []string) (string, commands.Command) {
 		tokens[1], // Route
 		tokens[2], // Name
 	)
-	return "add_channel", ac
+	return CMD_CHANNEL_ADD, ac
 }
 
 func parseAddTransformerV1(tokens []string) (string, commands.Command) {
-	if !verifyTokenLength(tokens, 4, "add_transformer") {
-		return "add_transformer", nil
+	if !verifyTokenLength(tokens, 4, CMD_TRANSFORMER_ADD) {
+		return CMD_TRANSFORMER_ADD, nil
 	}
 
 	at := commands.NewAddTransformer(
@@ -114,5 +114,5 @@ func parseAddTransformerV1(tokens []string) (string, commands.Command) {
 		tokens[2], // Channel
 		tokens[3], // Address
 	)
-	return "add_transformer", at
+	return CMD_TRANSFORMER_ADD, at
 }

--- a/parsing/one_test.go
+++ b/parsing/one_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func TestParseDataV1_SendMessage_OK(t *testing.T) {
-	tokens := []string{"send_message", "id-1", "orders.created", "hello"}
+	tokens := []string{"MESSAGE.SEND", "id-1", "orders.created", "hello"}
 	typ, cmd := parseDataV1(tokens)
 
-	if typ != "send_message" {
-		t.Fatalf("type mismatch: want %q, got %q", "send_message", typ)
+	if typ != "MESSAGE.SEND" {
+		t.Fatalf("type mismatch: want %q, got %q", "MESSAGE.SEND", typ)
 	}
 	if cmd == nil {
 		t.Fatalf("expected non-nil command")
@@ -27,11 +27,11 @@ func TestParseDataV1_SendMessage_OK(t *testing.T) {
 }
 
 func TestParseDataV1_AddRoute_OK(t *testing.T) {
-	tokens := []string{"add_route", "id-2", "orders"}
+	tokens := []string{"ROUTE.ADD", "id-2", "orders"}
 	typ, cmd := parseDataV1(tokens)
 
-	if typ != "add_route" || cmd == nil {
-		t.Fatalf("want add_route non-nil, got typ=%q cmd=%v", typ, cmd)
+	if typ != "ROUTE.ADD" || cmd == nil {
+		t.Fatalf("want ROUTE.ADD non-nil, got typ=%q cmd=%v", typ, cmd)
 	}
 	ar, ok := cmd.(*commands.AddRoute)
 	if !ok {
@@ -44,12 +44,12 @@ func TestParseDataV1_AddRoute_OK(t *testing.T) {
 
 func TestParseDataV1_AddSubscriber_OK(t *testing.T) {
 	tokens := []string{
-		"add_subscriber", "id-3", "orders", "primary", "127.0.0.1:7001",
+		"SUBSCRIBER.ADD", "id-3", "orders", "primary", "127.0.0.1:7001",
 	}
 	typ, cmd := parseDataV1(tokens)
 
-	if typ != "add_subscriber" || cmd == nil {
-		t.Fatalf("want add_subscriber non-nil, got typ=%q cmd=%v", typ, cmd)
+	if typ != "SUBSCRIBER.ADD" || cmd == nil {
+		t.Fatalf("want SUBSCRIBER.ADD non-nil, got typ=%q cmd=%v", typ, cmd)
 	}
 	as, ok := cmd.(*commands.AddSubscriber)
 	if !ok {
@@ -61,11 +61,11 @@ func TestParseDataV1_AddSubscriber_OK(t *testing.T) {
 }
 
 func TestParseDataV1_AddChannel_OK(t *testing.T) {
-	tokens := []string{"add_channel", "id-4", "orders", "primary"}
+	tokens := []string{"CHANNEL.ADD", "id-4", "orders", "primary"}
 	typ, cmd := parseDataV1(tokens)
 
-	if typ != "add_channel" || cmd == nil {
-		t.Fatalf("want add_channel non-nil, got typ=%q cmd=%v", typ, cmd)
+	if typ != "CHANNEL.ADD" || cmd == nil {
+		t.Fatalf("want CHANNEL.ADD non-nil, got typ=%q cmd=%v", typ, cmd)
 	}
 	ac, ok := cmd.(*commands.AddChannel)
 	if !ok {
@@ -78,12 +78,12 @@ func TestParseDataV1_AddChannel_OK(t *testing.T) {
 
 func TestParseDataV1_AddTransformer_OK(t *testing.T) {
 	tokens := []string{
-		"add_transformer", "id-5", "orders", "primary", "127.0.0.1:7100",
+		"TRANSFORMER.ADD", "id-5", "orders", "primary", "127.0.0.1:7100",
 	}
 	typ, cmd := parseDataV1(tokens)
 
-	if typ != "add_transformer" || cmd == nil {
-		t.Fatalf("want add_transformer non-nil, got typ=%q cmd=%v", typ, cmd)
+	if typ != "TRANSFORMER.ADD" || cmd == nil {
+		t.Fatalf("want TRANSFORMER.ADD non-nil, got typ=%q cmd=%v", typ, cmd)
 	}
 	at, ok := cmd.(*commands.AddTransformer)
 	if !ok {
@@ -106,8 +106,8 @@ func TestParseDataV1_Unknown_ReturnsEmptyAndNil(t *testing.T) {
 
 func TestParseSendMsgV1_BadLength_ReturnsNil(t *testing.T) {
 	typ, cmd := parseSendMsgV1([]string{"only-two", "tokens"})
-	if typ != "send_message" {
-		t.Fatalf("want type 'send_message', got %q", typ)
+	if typ != "MESSAGE.SEND" {
+		t.Fatalf("want type 'MESSAGE.SEND', got %q", typ)
 	}
 	if cmd != nil {
 		t.Fatalf("expected nil cmd for bad length, got %T", cmd)
@@ -116,33 +116,33 @@ func TestParseSendMsgV1_BadLength_ReturnsNil(t *testing.T) {
 
 func TestParseAddRouteV1_BadLength_ReturnsNil(t *testing.T) {
 	typ, cmd := parseAddRouteV1([]string{"only-one"})
-	if typ != "add_route" || cmd != nil {
-		t.Fatalf("expected add_route + nil cmd, got typ=%q cmd=%v", typ, cmd)
+	if typ != "ROUTE.ADD" || cmd != nil {
+		t.Fatalf("expected ROUTE.ADD + nil cmd, got typ=%q cmd=%v", typ, cmd)
 	}
 }
 
 func TestParseAddSubscriberV1_BadLength_ReturnsNil(t *testing.T) {
 	typ, cmd := parseAddSubscriberV1([]string{"id", "route", "only-three"})
-	if typ != "add_subscriber" || cmd != nil {
+	if typ != "SUBSCRIBER.ADD" || cmd != nil {
 		t.Fatalf(
-			"expected add_subscriber + nil cmd, got typ=%q cmd=%v", typ, cmd,
+			"expected SUBSCRIBER.ADD + nil cmd, got typ=%q cmd=%v", typ, cmd,
 		)
 	}
 }
 
 func TestParseAddChannelV1_BadLength_ReturnsNil(t *testing.T) {
 	typ, cmd := parseAddChannelV1([]string{"id", "route"})
-	if typ != "add_channel" || cmd != nil {
-		t.Fatalf("expected add_channel + nil cmd, got typ=%q cmd=%v", typ, cmd)
+	if typ != "CHANNEL.ADD" || cmd != nil {
+		t.Fatalf("expected CHANNEL.ADD + nil cmd, got typ=%q cmd=%v", typ, cmd)
 	}
 }
 
 func TestParseAddTransformerV1_BadLength_ReturnsNil(t *testing.T) {
 	typ, cmd := parseAddTransformerV1([]string{"id", "route", "channel"})
 	// missing address
-	if typ != "add_transformer" || cmd != nil {
+	if typ != "TRANSFORMER.ADD" || cmd != nil {
 		t.Fatalf(
-			"expected add_transformer + nil cmd, got typ=%q cmd=%v", typ, cmd,
+			"expected TRANSFORMER.ADD + nil cmd, got typ=%q cmd=%v", typ, cmd,
 		)
 	}
 }

--- a/parsing/parsing.go
+++ b/parsing/parsing.go
@@ -37,6 +37,18 @@ func ParseLine(line []byte) (string, commands.Command) {
 
 	args := parts[1:] // prune off protocol version token.
 
+	// The broker always works off of the same types of command objects.
+	// Command objects may evolve over time, adding new fields for new
+	// functionality, but the broker should remain compatible with previous
+	// client side API versions.
+
+	// If a client is using API ver 1 to communicate with Broker ver 2, then the
+	// client should be able to still communicate.
+	// This first token of a message is the API version, and this switch runs
+	// the corresponding parsing logic.
+
+	// This is mainly because early on there was uncertainty if the protocol and
+	// command structure was done right.
 	switch version {
 	case 1:
 		return parseDataV1(args)

--- a/str/str.go
+++ b/str/str.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"mycelia/errgo"
+
+	"golang.org/x/term"
 )
 
 func getVerbosity() int {
@@ -59,4 +62,20 @@ func PrettyPrintStrKeyJson(data map[string]any) {
 		return
 	}
 	fmt.Println(string(b))
+}
+
+// Prints "-" repeated to fill the terminal lenght if a terminal is being used
+// for Stdout, otherwise repeats 80 times.
+func PrintAsciiLine() {
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		width, _, err := term.GetSize(int(os.Stdout.Fd()))
+		if err != nil {
+			fmt.Println(strings.Repeat("-", 80))
+			return
+		} else {
+			fmt.Println(strings.Repeat("-", width))
+		}
+	} else {
+		fmt.Println(strings.Repeat("-", 80))
+	}
 }


### PR DESCRIPTION
closes #40 

Parsing for API v1 does not use command syntax to parse sub-commands, but it does set it up for future version and adds semantic clarity.